### PR TITLE
Update config option to new value

### DIFF
--- a/commonmarker-rouge.gemspec
+++ b/commonmarker-rouge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'commonmarker', '>= 0.16.0', '< 1.0'
+  spec.add_dependency 'commonmarker', '>= 0.14.5', '< 1.0'
   spec.add_dependency 'rouge',        '~> 1.10'
 
   spec.add_development_dependency 'bundler',  '~> 1.11'

--- a/commonmarker-rouge.gemspec
+++ b/commonmarker-rouge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'commonmarker', '> 0.8.0', '< 1.0'
+  spec.add_dependency 'commonmarker', '>= 0.16.0', '< 1.0'
   spec.add_dependency 'rouge',        '~> 1.10'
 
   spec.add_development_dependency 'bundler',  '~> 1.11'

--- a/lib/commonmarker/rouge.rb
+++ b/lib/commonmarker/rouge.rb
@@ -7,7 +7,7 @@ module CommonMarker
   module Rouge
     module_function
 
-    def render_doc(text, cmark_options = :default, **highmark_options)
+    def render_doc(text, cmark_options = :DEFAULT, **highmark_options)
       cmark = highmark_options[:cmark_class] || ::CommonMarker
 
       ast = cmark.render_doc(text, cmark_options)
@@ -15,7 +15,7 @@ module CommonMarker
       ast
     end
 
-    def render_html(text, cmark_options = :default)
+    def render_html(text, cmark_options = :DEFAULT)
       render_doc(text, cmark_options).to_html
     end
 


### PR DESCRIPTION
As of CommonMarker 0.14.5, all the symbol names have been capitalized. This
updates the code to use the latest version of commonmarker and fix the symbol
names in #render_html and #render_doc.

See: https://github.com/gjtorikian/commonmarker/pull/36