### PR TITLE
Add language-n class to container

### DIFF
--- a/lib/commonmarker/rouge.rb
+++ b/lib/commonmarker/rouge.rb
@@ -27,7 +27,7 @@ module CommonMarker
 
           source = node.string_content
 
-          lexer = ::Rouge::Lexer.find_fancy(node.fence_info)
+          lexer = ::Rouge::Lexer.find_fancy(node.fence_info) || ::Rouge::Lexers::PlainText
 
           formatter = (highmark_options[:formatter] || ::Rouge::Formatters::HTML).new(highmark_options[:options] || {})
 

--- a/lib/commonmarker/rouge.rb
+++ b/lib/commonmarker/rouge.rb
@@ -2,6 +2,7 @@ require 'commonmarker/rouge/version'
 
 require 'commonmarker'
 require 'rouge'
+require 'cgi'
 
 module CommonMarker
   module Rouge
@@ -30,7 +31,7 @@ module CommonMarker
 
           formatter = (highmark_options[:formatter] || ::Rouge::Formatters::HTML).new(highmark_options[:options] || {})
 
-          html = '<div class="highlighter-rouge language-' + node.fence_info + '">' + formatter.format(lexer.lex(source)) + '</div>'
+          html = '<div class="highlighter-rouge language-' + CGI.escapeHTML(node.fence_info) + '">' + formatter.format(lexer.lex(source)) + '</div>'
 
           new_node = ::CommonMarker::Node.new(:html)
           new_node.string_content = html

--- a/lib/commonmarker/rouge.rb
+++ b/lib/commonmarker/rouge.rb
@@ -30,7 +30,7 @@ module CommonMarker
 
           formatter = (highmark_options[:formatter] || ::Rouge::Formatters::HTML).new(highmark_options[:options] || {})
 
-          html = '<div class="highlighter-rouge">' + formatter.format(lexer.lex(source)) + '</div>'
+          html = '<div class="highlighter-rouge language-' + node.fence_info + '">' + formatter.format(lexer.lex(source)) + '</div>'
 
           new_node = ::CommonMarker::Node.new(:html)
           new_node.string_content = html

--- a/spec/commonmarker_rouge_spec.rb
+++ b/spec/commonmarker_rouge_spec.rb
@@ -16,4 +16,19 @@ MD
 
     expect(html).to_not eq('')
   end
+
+  it 'escapes language markup' do
+    html = CommonMarker::Rouge.render_html(<<-MD)
+```haxxor">yay!
+somecode
+```
+MD
+
+    expected = <<-HTML
+<div class="highlighter-rouge language-haxxor&quot;&gt;yay!"><pre class=\"highlight\"><code>somecode
+</code></pre>
+</div>
+HTML
+    expect(html).to eq(expected)
+  end
 end


### PR DESCRIPTION
Adds a `language-ruby`, for example, class to the container so you can style highlighters based on lexer.